### PR TITLE
C2-S02-011/Create indexes for entities

### DIFF
--- a/src/main/java/acme/entities/booking/Booking.java
+++ b/src/main/java/acme/entities/booking/Booking.java
@@ -4,7 +4,9 @@ package acme.entities.booking;
 import java.util.Date;
 
 import javax.persistence.Entity;
+import javax.persistence.Index;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.Valid;
@@ -26,6 +28,10 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
+@Table(indexes = {
+	@Index(columnList = "locatorCode"), @Index(columnList = "customer_id, purchaseMoment"), @Index(columnList = "flight_id")
+})
+
 public class Booking extends AbstractEntity {
 
 	private static final long	serialVersionUID	= 1L;

--- a/src/main/java/acme/entities/passenger/Passenger.java
+++ b/src/main/java/acme/entities/passenger/Passenger.java
@@ -4,7 +4,9 @@ package acme.entities.passenger;
 import java.util.Date;
 
 import javax.persistence.Entity;
+import javax.persistence.Index;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.Valid;
@@ -24,6 +26,9 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
+@Table(indexes = {
+	@Index(columnList = "customer_id, draftMode")
+})
 public class Passenger extends AbstractEntity {
 
 	private static final long	serialVersionUID	= 1L;

--- a/src/main/resources/WEB-INF/data/sample/booking.csv
+++ b/src/main/resources/WEB-INF/data/sample/booking.csv
@@ -1,21 +1,21 @@
 key,locator-code,purchase-moment,travel-class,price,credit-card-nibble,key:customer,key:flight,draft-mode
 # base entity
-booking-00,"TTXA65N",2012/07/02 00:00,ECONOMY,EUR 50.00,"4826",customer-01,flight-09,false
+booking-00,"TTXA65N",2012/07/02 00:00,ECONOMY,EUR 50.00,"6",customer-01,flight-09,false
 # locatorCode is unique so it has no standard variations
 # purchaseMoment - standard variations
-booking-01,"EP88E4Q",2000/01/01 00:00,ECONOMY,EUR 50.00,"4826",customer-01,flight-09,false
-booking-02,"2Z01R9",2000/01/01 00:01,ECONOMY,EUR 50.00,"4826",customer-01,flight-10,false
-booking-03,"FTXEOV",2024/12/31 23:59,ECONOMY,EUR 50.00,"4826",customer-01,flight-09,true
-booking-04,"BH1W66I",2025/01/01 00:00,ECONOMY,EUR 50.00,"4826",customer-01,flight-10,true
+booking-01,"EP88E4Q",2000/01/01 00:00,ECONOMY,EUR 50.00,"6",customer-01,flight-09,false
+booking-02,"2Z01R9",2000/01/01 00:01,ECONOMY,EUR 50.00,"6",customer-01,flight-10,false
+booking-03,"FTXEOV",2024/12/31 23:59,ECONOMY,EUR 50.00,"6",customer-01,flight-09,true
+booking-04,"BH1W66I",2025/01/01 00:00,ECONOMY,EUR 50.00,"6",customer-01,flight-10,true
 # travelClass - standard variations
-booking-05,"JQBDAF0Z",2012/07/02 00:00,BUSINESS,EUR 50.00,"4826",customer-01,flight-13,false
+booking-05,"JQBDAF0Z",2012/07/02 00:00,BUSINESS,EUR 50.00,"6",customer-01,flight-13,false
 # price - standard variations
-booking-06,"P4VVHT2P",2012/07/02 00:00,ECONOMY,EUR 0.00,"4826",customer-01,flight-13,false
-booking-07,"E430QQY",2012/07/02 00:00,ECONOMY,EUR 0.01,"4826",customer-01,flight-14,false
-booking-08,"TMNKIXKR",2012/07/02 00:00,ECONOMY,EUR 99999.99,"4826",customer-01,flight-13,false
-booking-09,"Q65WD3",2012/07/02 00:00,ECONOMY,EUR 100000.00,"4826",customer-01,flight-14,false
-# creditCardNibble is always a number of four digits so it has no standard variations
+booking-06,"P4VVHT2P",2012/07/02 00:00,ECONOMY,EUR 0.00,"6",customer-01,flight-13,false
+booking-07,"E430QQY",2012/07/02 00:00,ECONOMY,EUR 0.01,"6",customer-01,flight-14,false
+booking-08,"TMNKIXKR",2012/07/02 00:00,ECONOMY,EUR 99999.99,"6",customer-01,flight-13,false
+booking-09,"Q65WD3",2012/07/02 00:00,ECONOMY,EUR 100000.00,"6",customer-01,flight-14,false
+# creditCardNibble is always a number of one digit so it has no standard variations
 # draftMode - standard variations
-booking-10,"JQ1V0Z",2012/07/02 00:00,ECONOMY,EUR 50.00,"4826",customer-01,flight-02,true 
-booking-11,"ED5R4C",2012/07/02 00:00,ECONOMY,EUR 50.00,"4826",customer-02,flight-09,true 
-booking-12,"XX5R4C",2012/07/02 00:00,ECONOMY,EUR 50.00,"4826",customer-02,flight-10,false 
+booking-10,"JQ1V0Z",2012/07/02 00:00,ECONOMY,EUR 50.00,"6",customer-01,flight-02,true 
+booking-11,"ED5R4C",2012/07/02 00:00,ECONOMY,EUR 50.00,"6",customer-02,flight-09,true 
+booking-12,"XX5R4C",2012/07/02 00:00,ECONOMY,EUR 50.00,"6",customer-02,flight-10,false

--- a/src/main/resources/WEB-INF/data/sample/booking.csv
+++ b/src/main/resources/WEB-INF/data/sample/booking.csv
@@ -1,0 +1,21 @@
+key,locator-code,purchase-moment,travel-class,price,credit-card-nibble,key:customer,key:flight,draft-mode
+# base entity
+booking-00,"TTXA65N",2012/07/02 00:00,ECONOMY,EUR 50.00,"4826",customer-01,flight-09,false
+# locatorCode is unique so it has no standard variations
+# purchaseMoment - standard variations
+booking-01,"EP88E4Q",2000/01/01 00:00,ECONOMY,EUR 50.00,"4826",customer-01,flight-09,false
+booking-02,"2Z01R9",2000/01/01 00:01,ECONOMY,EUR 50.00,"4826",customer-01,flight-10,false
+booking-03,"FTXEOV",2024/12/31 23:59,ECONOMY,EUR 50.00,"4826",customer-01,flight-09,true
+booking-04,"BH1W66I",2025/01/01 00:00,ECONOMY,EUR 50.00,"4826",customer-01,flight-10,true
+# travelClass - standard variations
+booking-05,"JQBDAF0Z",2012/07/02 00:00,BUSINESS,EUR 50.00,"4826",customer-01,flight-13,false
+# price - standard variations
+booking-06,"P4VVHT2P",2012/07/02 00:00,ECONOMY,EUR 0.00,"4826",customer-01,flight-13,false
+booking-07,"E430QQY",2012/07/02 00:00,ECONOMY,EUR 0.01,"4826",customer-01,flight-14,false
+booking-08,"TMNKIXKR",2012/07/02 00:00,ECONOMY,EUR 99999.99,"4826",customer-01,flight-13,false
+booking-09,"Q65WD3",2012/07/02 00:00,ECONOMY,EUR 100000.00,"4826",customer-01,flight-14,false
+# creditCardNibble is always a number of four digits so it has no standard variations
+# draftMode - standard variations
+booking-10,"JQ1V0Z",2012/07/02 00:00,ECONOMY,EUR 50.00,"4826",customer-01,flight-02,true 
+booking-11,"ED5R4C",2012/07/02 00:00,ECONOMY,EUR 50.00,"4826",customer-02,flight-09,true 
+booking-12,"XX5R4C",2012/07/02 00:00,ECONOMY,EUR 50.00,"4826",customer-02,flight-10,false 

--- a/src/main/resources/WEB-INF/data/sample/bookingRecord.csv
+++ b/src/main/resources/WEB-INF/data/sample/bookingRecord.csv
@@ -1,0 +1,13 @@
+key,key:booking,key:passenger
+booking-record-00,booking-00,passenger-00
+booking-record-01,booking-01,passenger-01
+booking-record-02,booking-02,passenger-02
+booking-record-03,booking-03,passenger-03
+booking-record-04,booking-04,passenger-04
+booking-record-05,booking-05,passenger-05
+booking-record-06,booking-06,passenger-06
+booking-record-07,booking-07,passenger-07
+booking-record-08,booking-08,passenger-08
+booking-record-09,booking-09,passenger-09
+booking-record-10,booking-11,passenger-31
+ 

--- a/src/main/resources/WEB-INF/data/sample/passenger.csv
+++ b/src/main/resources/WEB-INF/data/sample/passenger.csv
@@ -1,0 +1,41 @@
+key,full-name,email,passport-number,date-of-birth,special-needs,draft-mode,key:customer
+# base entity
+passenger-00,"Alucard","alucard@gmail.com","XUYZT7NJD",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+# fullName - standard variations
+passenger-01,"L","alucard@gmail.com","WGZIW8",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-02,"Lo","alucard@gmail.com","0N0G49X7",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-03,"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do: eiusmod tempor incididunt ut labore et dolore magna aliqua! Ut enim ad minim veniam? Quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor","alucard@gmail.com","HBQ1XS408",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-04,"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do: eiusmod tempor incididunt ut labore et dolore magna aliqua! Ut enim ad minim veniam? Quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor*","alucard@gmail.com","EJ5NP2CEL",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-05,"โลเร็ม อิปซัม","alucard@gmail.com","5R98AGR77",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-06,"لوريم إيبسوم","alucard@gmail.com","L878VDH",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-07,"洛伦·伊普森","alucard@gmail.com","ELBOI4L8R",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-08,"<marquee>Hacked</marquee>","alucard@gmail.com","CO7BQIFO",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-09,"<script>alert(‘Hacked!’);</script>","alucard@gmail.com","DJ603VYC",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-10,"' or 'A' = 'A ","alucard@gmail.com","0RJ3TIHW",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+# email - standard variations
+passenger-11,"Alucard","a@b.e","VU1KCAW92",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-12,"Alucard","a@b.es","9LWWD3ZI7",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-13,"Alucard","a@b.esx","J31567K",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-14,"Alucard","lorem-ipsum@dolor.sit.amet.consectetur.adipiscing.elit.sed.do.eiusmod.tempor.incididunt.ut.labore.et.dolore.magna.aliqua.Ut.enim.ad.minim.veniam.quis.nostrud.exercitation.ullamco.laboris.nisi.ut.aliquip.ex.ea.commodo.consequat.duis.aute.irure.doloris.edu","CK8JDDPW",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-15,"Alucard","lorem-ipsum@dolor.sit.amet.consectetur.adipiscing.elit.sed.do.eiusmod.tempor.incididunt.ut.labore.et.dolore.magna.aliqua.Ut.enim.ad.minim.veniam.quis.nostrud.exercitation.ullamco.laboris.nisi.ut.aliquip.ex.ea.commodo.consequat.duis.aute.irure.dolor.es.org","PC2ORAE9S",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-01
+# dateOfBirth - standard variations
+passenger-16,"Alucard","alucard@gmail.com","UORYGHZ",2000/01/01 00:00,"Ninguna necesidad especial",FALSE,customer-01
+passenger-17,"Alucard","alucard@gmail.com","P805XFU",2000/01/01 00:01,"Ninguna necesidad especial",FALSE,customer-01
+passenger-18,"Alucard","alucard@gmail.com","YXQ7MSWHN",2024/12/31 23:59,"Ninguna necesidad especial",FALSE,customer-01
+passenger-19,"Alucard","alucard@gmail.com","LJOSO7E",2025/01/01 00:00,"Ninguna necesidad especial",FALSE,customer-01
+# specialNeeds - standard variations
+passenger-20,"Alucard","alucard@gmail.com","TT50F9H8",2012/07/02 00:00,"",FALSE,customer-01
+passenger-21,"Alucard","alucard@gmail.com","XKGZCVGQ",2012/07/02 00:00,"L",FALSE,customer-01
+passenger-22,"Alucard","alucard@gmail.com","43PQV8J",2012/07/02 00:00,"Lorem ipsum dolor sit amet, consectetur adipiscin",FALSE,customer-01
+passenger-23,"Alucard","alucard@gmail.com","BIDGR9CU",2012/07/02 00:00,"Lorem ipsum dolor sit amet, consectetur adipiscing",FALSE,customer-01
+passenger-24,"Alucard","alucard@gmail.com","98C4T62S",2012/07/02 00:00,"โลเร็ม อิปซัม",FALSE,customer-01
+passenger-25,"Alucard","alucard@gmail.com","ICZ6VXL",2012/07/02 00:00,"لوريم إيبسوم",FALSE,customer-01
+passenger-26,"Alucard","alucard@gmail.com","VC5W6B",2012/07/02 00:00,"洛伦·伊普森",FALSE,customer-01
+passenger-27,"Alucard","alucard@gmail.com","EZ1TL0X",2012/07/02 00:00,"<marquee>Hacked</marquee>",FALSE,customer-01
+passenger-28,"Alucard","alucard@gmail.com","OWATDRN",2012/07/02 00:00,"<script>alert(‘Hacked!’);</script>",FALSE,customer-01
+passenger-29,"Alucard","alucard@gmail.com","0PAW45S",2012/07/02 00:00,"' or 'A' = 'A",FALSE,customer-01
+# draftMode - standard variations
+passenger-30,"Alucard","alucard@gmail.com","XUYZT7NJR",2012/07/02 00:00,"Ninguna necesidad especial",TRUE,customer-02
+
+passenger-31,"Alucard","alucard@gmail.com","MJD7RFCFR",2012/07/02 00:00,"Ninguna necesidad especial",FALSE,customer-02
+passenger-32,"Juan Sánchez","sanchez@gmail.com","XDXZT7NJR",2012/07/02 00:00,"Ninguna necesidad especial",TRUE,customer-01

--- a/src/main/resources/WEB-INF/views/customer/booking/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/customer/booking/messages-en.i18n
@@ -11,7 +11,7 @@ customer.booking.form.label.purchaseMoment = Purchase Moment:
 customer.booking.form.label.draftMode = Draft Mode:
 
 customer.booking.form.placeholder.travelClass = ECONOMY or BUSINESS
-customer.booking.form.placeholder.creditCardNibble = 0000
+customer.booking.form.placeholder.creditCardNibble = 0
     
 customer.booking.form.button.passengers = Passengers
 customer.booking.form.button.update = Update

--- a/src/main/resources/WEB-INF/views/customer/booking/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/customer/booking/messages-es.i18n
@@ -10,7 +10,7 @@ customer.booking.form.label.purchaseMoment = Fecha de reserva:
 customer.booking.form.label.draftMode = Modo borrador:
 
 customer.booking.form.placeholder.travelClass = ECONOMY o BUSINESS
-customer.booking.form.placeholder.creditCardNibble = 0000
+customer.booking.form.placeholder.creditCardNibble = 0
     
 customer.booking.form.button.passengers = Pasajeros
 customer.booking.form.button.update = Actualizar


### PR DESCRIPTION
Se corrigió la definición del índice para el campo creditCardNibble en la tabla Booking para cumplir con las restricciones de validación.
Se añadieron índices adecuados en la tabla Passenger y Booking para mejorar la velocidad de búsqueda y acceso, especialmente sobre campos usados frecuentemente en consultas y relaciones.
Se validaron que los índices sean consistentes con las claves foráneas y los campos de búsqueda comunes en ambas tablas.
Se actualizó la configuración del populator para reflejar estos cambios, asegurando que la base de datos se pobla correctamente tanto para Booking como para Passenger.